### PR TITLE
INFRA-48 fix (date detection): adjusted regexp detecting date of last…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ sitewards_server_suicide_server_id: ""
 sitewards_server_suicide_termination_url: "http://showroom-hypervisor.sitewards.net/api/servers/{{ sitewards_server_suicide_server_id }}/terminate" 
 sitewards_server_suicide_stdin_data_feed: "echo ''" 
 sitewards_server_suicide_warm_up_url: ""
+
+sitewards_server_suicide_active: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,3 +27,4 @@
     user: "{{ sitewards_server_suicide_owner }}"
     minute: "{{ sitewards_server_suicide_cronjob_execution_interval }}"
     job: "{{ sitewards_server_suicide_stdin_data_feed }} | php {{ sitewards_server_suicide_base_path }}/monitor.php --termination \"{{ sitewards_server_suicide_termination_url }}\" --logfile \"{{ sitewards_server_suicide_logfile_path }}\" --interval \"{{ sitewards_server_suicide_server_termination_check_interval }}\""
+    when: sitewards_server_suicide_active

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,9 +22,10 @@
     status_code: 200, 201, 208, 301, 302
   when: sitewards_server_suicide_warm_up_url != ''
 
-- cron:
+- name: Create crontask to check for server activity in specified period.
+  when: sitewards_server_suicide_active|bool
+  cron:
     name: monitor server termination
     user: "{{ sitewards_server_suicide_owner }}"
     minute: "{{ sitewards_server_suicide_cronjob_execution_interval }}"
     job: "{{ sitewards_server_suicide_stdin_data_feed }} | php {{ sitewards_server_suicide_base_path }}/monitor.php --termination \"{{ sitewards_server_suicide_termination_url }}\" --logfile \"{{ sitewards_server_suicide_logfile_path }}\" --interval \"{{ sitewards_server_suicide_server_termination_check_interval }}\""
-    when: sitewards_server_suicide_active

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,9 +23,10 @@
   when: sitewards_server_suicide_warm_up_url != ''
 
 - name: Create crontask to check for server activity in specified period.
-  when: sitewards_server_suicide_active|bool
   cron:
     name: monitor server termination
     user: "{{ sitewards_server_suicide_owner }}"
     minute: "{{ sitewards_server_suicide_cronjob_execution_interval }}"
     job: "{{ sitewards_server_suicide_stdin_data_feed }} | php {{ sitewards_server_suicide_base_path }}/monitor.php --termination \"{{ sitewards_server_suicide_termination_url }}\" --logfile \"{{ sitewards_server_suicide_logfile_path }}\" --interval \"{{ sitewards_server_suicide_server_termination_check_interval }}\""
+    state: present
+    disabled: not sitewards_server_suicide_active

--- a/templates/monitor.php
+++ b/templates/monitor.php
@@ -63,7 +63,8 @@ function get_stdin()
 function is_stdin_expired($stdin, $logExpiryInterval)
 {
     // get datetime from the line and compare it to the current datetime
-    preg_match('/\[([^\[\]]*:[^\[\]]*)\]/', $stdin, $matches);
+    // to identify date in log regexp searches for a first value between square brackets that have at least 10 chars
+    preg_match('/\[([^\]]{10,}?)\]/', $stdin, $matches);
 
     // the access log is empty, or wrong format, consider it expired
     if (empty($matches)) {


### PR DESCRIPTION
… event

Initial regexp was getting first value within square brackets within log
line. In Ubuntu's systemctl however that is process id instead of date.
New regexp detects first value that is within square brackets and
has at least 10 characters.