### PR TITLE
ADHOC fix (time-calculations): conversion problem

### DIFF
--- a/templates/monitor.php
+++ b/templates/monitor.php
@@ -90,7 +90,7 @@ function is_access_log_expired($logfile, $logExpiryInterval)
 
     // the access log is empty, or wrong format, let's try to check mtime
     if (empty($matches)) {
-        $lastLogEntry = filemtime($logfile);
+        $lastLogEntry = DateTimeImmutable::createFromFormat('U', filemtime($logfile));
     } else {
         $lastLogEntry = new DateTimeImmutable($matches[1]);
     }


### PR DESCRIPTION
DateTimeImmutable can not be directly compared to Linux timestamp. To keep the
code consistent with the rest - adding a conversion of filemtime result to
DateTimeImmutable as well.