### PR TITLE
ADHOC fix (docs): proper shutdown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ defaults/main.yml file
 ### Parsing log file with the tool
 
 ```
-php monitor.php --logfile /var/log/php_errors.log --interval 4hours --termination "shutdown"
+php monitor.php --logfile /var/log/php_errors.log --interval 4hours --termination "/sbin/shutdown -h now"
 ```
 
 this will check if machine is running longer than `4 hours` and if last entry in the `/var/log/php_errors.log` file was 
@@ -45,7 +45,7 @@ made at least `4 hours` ago, if both are true - "shutdown" command will be execu
 
 it is also possible to parse log file manually and feed it in the script:
 ```
-grep nginx /var/log/syslog | grep -v "health_check" | tail -1  | php monitor.php --interval 20minutes --termination "shutdown"
+grep nginx /var/log/syslog | grep -v "health_check" | tail -1  | php monitor.php --interval 20minutes --termination "/sbin/shutdown -h now"
 ```
 
 PLEASE NOTE: only the last line of STDIN will be processed in this case, `--logfile` is ignored in this mode.


### PR DESCRIPTION
cron is running with sh, `shutdown` is not in the PATH and therefore it does
not work this way, so it is needed to specify the full path to the binary.